### PR TITLE
Progress bar - sticky feature

### DIFF
--- a/src/app/components/progress-bar/progress-bar.component.scss
+++ b/src/app/components/progress-bar/progress-bar.component.scss
@@ -8,6 +8,9 @@ $letra:#b6c2cf;
   height: 100%;
   padding: 20px;
   background-color: $background;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 .progress-text {
   margin-bottom: 10px;


### PR DESCRIPTION
We used the sticky feature for seeing the progress bar while the questions are reply/ The bar is configured to be on top of other content